### PR TITLE
#35-1 [Feat] refreshToken API 테스트 및 정리

### DIFF
--- a/src/main/java/com/project/storemanager_api/controller/AuthController.java
+++ b/src/main/java/com/project/storemanager_api/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.project.storemanager_api.controller;
 
 import com.project.storemanager_api.domain.user.dto.request.LoginRequestDto;
 import com.project.storemanager_api.domain.user.dto.request.ModifyUserRequestDto;
+import com.project.storemanager_api.domain.user.dto.request.RefreshTokenRequestDto;
 import com.project.storemanager_api.domain.user.dto.request.SignUpRequestDto;
 import com.project.storemanager_api.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -106,9 +107,9 @@ public class AuthController {
      * 리프레시 토큰을 이용해 새로운 토큰을 발급하는 엔드포인트
      * 클라이언트는 refreshToken을 JSON 바디로 전달해야 함.
      */
-    @PostMapping("/api/refresh")
-    public ResponseEntity<Map<String, Object>> refreshToken(@RequestBody Map<String, String> request) {
-        String refreshToken = request.get("refreshToken");
+    @PostMapping("/auth/refresh")
+    public ResponseEntity<Map<String, Object>> refreshToken(@RequestBody RefreshTokenRequestDto dto) {
+        String refreshToken = dto.getRefreshToken();
         log.info("리프레시 토큰 요청: {}", refreshToken);
         Map<String, Object> responseMap = userService.refreshToken(refreshToken);
         return ResponseEntity.ok(responseMap);

--- a/src/main/java/com/project/storemanager_api/domain/user/dto/request/RefreshTokenRequestDto.java
+++ b/src/main/java/com/project/storemanager_api/domain/user/dto/request/RefreshTokenRequestDto.java
@@ -1,0 +1,14 @@
+package com.project.storemanager_api.domain.user.dto.request;
+
+import lombok.*;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshTokenRequestDto {
+
+    private String refreshToken;
+}


### PR DESCRIPTION
1. 로그인시 엑세스토큰, 리프레시토큰을 발급, (리프레시토큰은 db에 저장)
2. 클라이언트에서 요청보낼때 엑세스토큰을 포함해서 보내다가, 
401응답을 받으면 refreshToken을 보내서 새로운 accessToken 받아옴.
3. 다시 새로운 accessToken으로 요청보낼때 포함해서 보냄.